### PR TITLE
Combine python and uv preferences

### DIFF
--- a/.cursor/python-and-uv.mdc
+++ b/.cursor/python-and-uv.mdc
@@ -1,0 +1,5 @@
+# Instructions
+- Use **Python 3.12** or newer for all development and examples.
+- Prefer `python` over other interpreters when running scripts.
+- Use `uv` for package management tasks instead of `pip`.
+- Example: run `uv pip install -e '.[test]'` to install test dependencies.


### PR DESCRIPTION
## Summary
- combine python and uv guidance into one MDC file
- remove separate cursor rules

## Testing
- `uv pip install -e '.[test]'` *(fails: No virtual environment found)*
- `python -m pytest -q` *(fails: No module named pytest)*