### PR TITLE
Add environment instructions for OpenAI key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the research project
+# Copy this file to .env and replace with your own values
+OPENAI_API_KEY=your-openai-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wheels/
 
 # Virtual environments
 .venv
+.env

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Install the project with test dependencies:
 pip install -e '.[test]'
 ```
 
+## Configuration
+
+The application expects an OpenAI API key to interact with LangChain and the
+OpenAI service. Copy the provided `.env.example` file to `.env` and replace the
+placeholder with your actual key:
+
+```bash
+cp .env.example .env
+echo "OPENAI_API_KEY=your-real-key" >> .env
+```
+
+The `python-dotenv` package automatically loads variables from the `.env` file
+when running `main.py`.
+
 ## Running the tests
 
 Use `pytest` to run the test suite:


### PR DESCRIPTION
## Summary
- document how to store the OPENAI_API_KEY
- provide `.env.example` template and ignore `.env`

## Testing
- `pytest -q` *(fails: command not found)*