### PR TITLE
Add pytest dependency for easier testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the research project
+# Copy this file to .env and replace with your own values
+OPENAI_API_KEY=your-openai-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wheels/
 
 # Virtual environments
 .venv
+.env

--- a/README.md
+++ b/README.md
@@ -11,11 +11,25 @@ python -m venv .venv
 source .venv/bin/activate
 ```
 
-Install the project with test dependencies:
+Install the project dependencies:
 
 ```bash
-pip install -e '.[test]'
+uv pip install .
 ```
+
+## Configuration
+
+The application expects an OpenAI API key to interact with LangChain and the
+OpenAI service. Copy the provided `.env.example` file to `.env` and replace the
+placeholder with your actual key:
+
+```bash
+cp .env.example .env
+echo "OPENAI_API_KEY=your-real-key" >> .env
+```
+
+The `python-dotenv` package automatically loads variables from the `.env` file
+when running `main.py`.
 
 ## Running the tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "langchain-openai~=0.3.17",
     "python-dotenv~=1.1.0", # For managing environment variables like API keys
     "langchain-community~=0.3.24", # For community-provided integrations
+    "pytest>=8.1", # For running the test suite
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- include pytest in default dependencies
- document `uv pip install .` for installing deps

## Testing
- `pip install -e .` *(fails: no access to PyPI)*
- `pytest -q` *(fails: command not found)*